### PR TITLE
Fix issue with column names not appearing for single-jagged-branch `dict`s

### DIFF
--- a/transformer.py
+++ b/transformer.py
@@ -139,9 +139,9 @@ def transform_single_file(file_path, output_path, servicex=None):
 
         start_serialization = time.time()
         try:
-            arrow = ak.to_arrow_table(awkward_array)
+            arrow = ak.to_arrow_table(awkward_array, explode_records=True)
         except TypeError:
-            arrow = ak.to_arrow_table(ak.repartition(awkward_array, None))
+            arrow = ak.to_arrow_table(ak.repartition(awkward_array, None), explode_records=True)
         end_serialization = time.time()
         print(f'awkward Array -> Arrow: {round(end_serialization - start_serialization, 2)} sec')
 


### PR DESCRIPTION
@kyungeonchoi pointed out that running the transformer on the `qastle` query `(Select (call EventDataset 'ServiceXDatasetSource' 'nominal') (lambda (list event) (dict (list 'jet_e') (list (attr event 'jet_e')))))` returns a Parquet file without any column names. This is because `ak.to_arrow_table()` won't expose the fields at the top level unless you set the `explode_records` argument. This is quite specific, as it doesn't happen unless there is exactly one branch in the `dict` *and* it's an array/vector branch.

This PR fixes this issue by setting the `explode_records` argument to `True`.