### PR TITLE
update some requirements to pull in bug fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-awkward==1.3.0
+awkward==1.5.0
 codecov==2.0.17
 confluent-kafka==1.4.0
 coverage==4.5.2
@@ -6,14 +6,14 @@ flake8==3.5.0
 kafka-python==2.0.1
 lz4==2.2.1
 minio==5.0.10
-numpy==1.16.6
+numpy==1.21.2
 pika==1.1.0
 pyarrow==3.0.0
 pytest==4.6.11
 pytest-mock==2.0.0
 requests==2.24.0
 servicex-transformer==1.0.1
-uproot==4.0.1
+uproot==4.1.3
 xxhash==1.4.4
 
 # There is no way the small amount of code written in this repo needs all this - are these


### PR DESCRIPTION
Get NumPy, Awkward, and Uproot updated to the latest versions. Most notably, this addresses an issue with trees with empty branches that was fixed in Uproot 4.1.3.