### PR TITLE
update XRootD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get install gnupg2 -y \
 RUN conda install --yes \
     -c conda-forge \
     lz4 \
-    xrootd==4.11.0 \
+    xrootd==5.1.1 \
     tini==0.18.0 \
     && conda clean -tipsy
 

--- a/transformer.py
+++ b/transformer.py
@@ -30,6 +30,7 @@ import sys
 import traceback
 
 import awkward as ak
+import uproot
 import time
 
 from servicex.transformer.servicex_adapter import ServiceXAdapter
@@ -44,7 +45,8 @@ import os
 import pyarrow.parquet as pq
 import pyarrow as pa
 
-
+# Needed until we use xrootd>=5.2.0 (see https://github.com/ssl-hep/ServiceX_Uproot_Transformer/issues/22)
+uproot.open.defaults["xrootd_handler"] = uproot.MultithreadedXRootDSource
 
 # How many bytes does an average awkward array cell take up. This is just
 # a rule of thumb to calculate chunksize


### PR DESCRIPTION
Hopefully addresses #22. We can't update past v5.1.1 without some major dependency changes.