### PR TITLE
Move user x509 cert proxy to /tmp dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN /opt/conda/bin/pip install safety==1.9.0
 RUN safety check -r requirements.txt
 RUN /opt/conda/bin/pip install --no-cache-dir -r requirements.txt
 
-ENV X509_USER_PROXY /etc/grid-security/x509up
+ENV X509_USER_PROXY=/tmp/grid-security/x509up
 
 WORKDIR /servicex
 COPY proxy-exporter.sh .
@@ -50,5 +50,5 @@ RUN chmod +x proxy-exporter.sh
 COPY transformer.py .
 COPY validate_requests.py .
 ENV PYTHONUNBUFFERED=1
-ENV X509_USER_PROXY=/etc/grid-security/x509up
+ENV X509_USER_PROXY=/tmp/grid-security/x509up
 

--- a/proxy-exporter.sh
+++ b/proxy-exporter.sh
@@ -1,11 +1,28 @@
 #!/usr/bin/env bash
-mkdir -p /etc/grid-security
+
+proxydir=$(dirname ${X509_USER_PROXY})
+
+if [[ ! -d $proxydir ]]
+then
+    mkdir -p $proxydir
+fi
 
 while true; do
-    cp /etc/grid-security-ro/x509up /etc/grid-security
-    chmod 600 /etc/grid-security/x509up
 
-    # Refresh every hour
-    sleep 3600
+    while true; do
+        cp /etc/grid-security-ro/x509up ${X509_USER_PROXY}
+        RESULT=$?
+        if [ $RESULT -eq 0 ]; then
+            echo "INFO $INSTANCE_NAME Uproot-Transformer  none Got proxy."
+            chmod 600 ${X509_USER_PROXY}
+            break
+        else
+            echo "WARNING $INSTANCE_NAME Uproot-Transformer none An issue encountered when getting proxy."
+            sleep 5
+        fi
+    done
+
+   # Refresh every hour
+   sleep 3600
 
 done


### PR DESCRIPTION
# Problem
OpenShift deployments can't write copies of the user proxy to /etc

Partial solution to [ServiceX Issue 364](https://github.com/ssl-hep/ServiceX/issues/364)

# Approach
Changed the X509_USER_PROXY to /tmp/grid-security/x509up