### PR TITLE
Fix dockerfile to handle updates to conda clean

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,11 @@ RUN apt-get install gnupg2 -y \
 
 RUN conda install --yes \
     -c conda-forge \
+    conda-build \
     lz4 \
     xrootd==5.1.1 \
     tini==0.18.0 \
-    && conda clean -tipsy
+    && conda build purge-all && conda clean -ti
 
 RUN conda install --yes \
     -c conda-forge \
@@ -27,7 +28,7 @@ RUN conda install --yes \
     pandas==0.25.3 \
     numba==0.48.0 \
     scipy==1.4.1 \
-    && conda clean -tipsy
+    && conda build purge-all && conda clean -ti
 
 RUN apt update && \
     apt upgrade -y && \


### PR DESCRIPTION
# Problem
Updates to conda have broken the Dockerfile. 
```
usage: conda clean [-h] [-a] [-i] [-p] [-t] [-f]
#7 553.5                    [-c [TEMPFILES [TEMPFILES ...]]] [-l] [-d] [--json] [-q]
#7 553.5                    [-v] [-y]
#7 553.5 conda clean: error: argument -p/--packages: ignored explicit argument 'sy'
------
executor failed running [/bin/sh -c conda install --yes     -c conda-forge     lz4     xrootd==5.1.1     tini==0.18.0     && conda clean -tipsy]: exit code: 2
```

# Approach
Change `conda clean -tipsy` to the new form of `conda build purge-all && conda clean -ti`

This required installing the new tool, `conda build`